### PR TITLE
build: add build and test workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the build and testing process for Rust projects. The workflow is triggered on pushes and pull requests to the `main` branch.

### CI/CD Workflow Addition:

* [`.github/workflows/rust.yml`](diffhunk://#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792dR1-R22): Added a new workflow named "Rust" that runs on `ubuntu-latest`. It checks out the code, builds the project using `cargo build --verbose`, and runs tests using `cargo test --verbose`. The workflow is triggered on push and pull request events targeting the `main` branch.