### PR TITLE
build: remove node cache for pnpm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'pnpm'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
This pull request makes a minor adjustment to the `.github/workflows/release.yml` file by removing the `cache: 'pnpm'` configuration from the `setup-node` action. This change simplifies the workflow configuration and may indicate a shift in caching strategy.